### PR TITLE
correcting editUrl to include /blob/main for editing on GitHub

### DIFF
--- a/layouts/partials/github-edit.html
+++ b/layouts/partials/github-edit.html
@@ -1,7 +1,7 @@
 <div class="col col-4">
     {{ $repoUrl := .Site.Params.repositoryUrl }}
     {{ $filePath := .File.Path }}
-    {{ $editUrl := print $repoUrl "/content/" $filePath }}
+    {{ $editUrl := print $repoUrl "/blob/main/content/" $filePath }}
     <a href="{{ $editUrl }}" class="btn btn-primary" target="_blank">
       <span class="fas fa-pen"></span> &nbsp; Edit on GitHub
     </a>


### PR DESCRIPTION
fixes #28 
