### PR TITLE
Updating section-nav.html

### DIFF
--- a/layouts/partials/section-nav.html
+++ b/layouts/partials/section-nav.html
@@ -12,7 +12,7 @@
           <ul>
             <li>
             <a {{ if $isThisPage }} class="active" {{ end }} href="{{ .RelPermalink }}">
-              {{ .Title | markdownify }}
+              {{ .LinkTitle | markdownify }}
             </a>
             </li>
           </ul>
@@ -23,7 +23,7 @@
           <ul>
             {{ range .CurrentSection.RegularPages }}
             <li>
-                <a {{ if $isThisPage }} class="active" {{ end }} href="{{ .RelPermalink }}">{{ .Page.Title | markdownify }}</a>
+                <a {{ if $isThisPage }} class="active" {{ end }} href="{{ .RelPermalink }}">{{ .Page.LinkTitle | markdownify }}</a>
             </li>
             {{ end }}
           </ul>


### PR DESCRIPTION
Using .LinkTitle will use markdown front matter "linkTitle" before "title"

fixes #27 