### PR TITLE
correcting links on the front page

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -112,8 +112,8 @@ on the Kubernetes Slack, or join the [Dex-dev][dex-dev] mailing list.
 
 [openid-connect]: https://openid.net/connect/
 [standard-claims]: https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims
-[scopes]: Documentation/custom-scopes-claims-clients.md#scopes
-[using-dex]: Documentation/using-dex.md
+[scopes]: docs/custom-scopes-claims-clients.md#scopes
+[using-dex]: docs/using-dex/
 [jwt-io]: https://jwt.io/
 [kubernetes]: http://kubernetes.io/docs/admin/authentication/#openid-connect-tokens
 [aws-sts]: https://docs.aws.amazon.com/STS/latest/APIReference/Welcome.html


### PR DESCRIPTION
Correcting links that 404 on the front page.

Fixes https://github.com/dexidp/website/issues/25.
More discussion may be needed for https://github.com/dexidp/website/issues/26.