### PR TITLE
Always cache into cacheDir

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -4,6 +4,23 @@ copyright = "Dex IdP Contributors"
 
 enableGitInfo = true
 
+[caches]
+ [caches.assets]
+  dir = ":cacheDir/_gen"
+  maxAge = -1
+ [caches.getcsv]
+  dir = ":cacheDir/:project"
+  maxAge = "60s"
+ [caches.getjson]
+  dir = ":cacheDir/:project"
+  maxAge = "60s"
+ [caches.images]
+  dir = ":cacheDir/_images"
+  maxAge = -1
+ [caches.modules]
+  dir = ":cacheDir/modules"
+  maxAge = -1
+
 [markup.highlight]
 style = "paraiso-dark"
 


### PR DESCRIPTION
By default Hugo puts some cache information outside of its `cacheDir`. Set Hugo to write all cached files inside the configured cache directory.