### PR TITLE
connectors: add warning to the SAML connector

### DIFF
--- a/content/docs/connectors/saml.md
+++ b/content/docs/connectors/saml.md
@@ -8,6 +8,10 @@ toc: true
 weight: 30
 ---
 
+## WARNING
+
+The SAML connector is unmaintained, likely vulnerable to authentication bypass vulnerablities, and is under consideration for deprecation (see [#1884](https://github.com/dexidp/dex/discussions/1884)). Please consider switching to OpenID Connect, OAuth2, or LDAP for identity providers that support these protocols. If you have domain expertise in SAML/XMLDSig and would like to volunteer to maintain the connector please comment on the discussion.
+
 ## Overview
 
 The SAML provider allows authentication through the SAML 2.0 HTTP POST binding. The connector maps attribute values in the SAML assertion to user info, such as username, email, and groups.


### PR DESCRIPTION
Add a warning to indicate that this connector is unmaintained and likely
vulnerable to auth bypasses.

Regardless of the decision to deprecate the connector, I think this is
important to communicate to potential users.

https://github.com/dexidp/dex/discussions/1884