### PR TITLE
Update BitbucketCloud OAuth2 consumer required permissions

### DIFF
--- a/content/docs/connectors/bitbucketcloud.md
+++ b/content/docs/connectors/bitbucketcloud.md
@@ -18,7 +18,9 @@ When a client redeems a refresh token through dex, dex will re-query Bitbucket t
 
 Register a new OAuth consumer with [Bitbucket](https://confluence.atlassian.com/bitbucket/oauth-on-bitbucket-cloud-238027431.html) ensuring the callback URL is `(dex issuer)/callback`. For example if dex is listening at the non-root path `https://auth.example.com/dex` the callback would be `https://auth.example.com/dex/callback`.
 
-The application requires the user to grant only the `Read Account` permission.
+There are several permissions required for an OAuth consumer to use it with Dex:
+* `Account: Read` - required for extracting base information (email, username)
+* `Workspace membership: Read` - only necessary to get user's teams
 
 The following is an example of a configuration for `examples/config-dev.yaml`:
 


### PR DESCRIPTION
It became mandatory to give Bitbucket OAuth consumer access to read workspace membership for getting user's teams.