### PR TITLE
Fix syntax error in openshift connector doc

### DIFF
--- a/content/docs/connectors/openshift.md
+++ b/content/docs/connectors/openshift.md
@@ -29,7 +29,7 @@ OpenShift Service Accounts can be used as a constrained form of OAuth client. Ma
 Patch the Service Account to add an annotation for location of the Redirect URI
 
 ```bash
-oc patch serviceaccount <name> --type='json' -p='[{"op": "add", "path": "/metadata/annotations/serviceaccounts.openshift.io/oauth-redirecturi.dex", "value":"https:///<dex_url>/callback"}]'
+oc patch serviceaccount <name> --type='json' -p='[{"op": "add", "path": "/metadata/annotations/serviceaccounts.openshift.io~1oauth-redirecturi.dex", "value":"https://<dex_url>/callback"}]'
 ```
 
 The Client ID for a Service Account representing an OAuth Client takes the form `system:serviceaccount:<namespace>:<service_account_name>`


### PR DESCRIPTION
'/' is not allowed as part of an annotation name; ecape character is '~1' for '/' in kubernetes due to:
https://github.com/kubernetes/kubernetes/issues/26890
https://tools.ietf.org/html/rfc6901#section-4