### PR TITLE
Adding a `versionintroduced` variable to the frontmatter of connector pages

### DIFF
--- a/content/docs/connectors/atlassian-crowd.md
+++ b/content/docs/connectors/atlassian-crowd.md
@@ -6,6 +6,7 @@ date: 2020-09-30
 draft: false
 toc: true
 weight: 2120
+versionintroduced: "v0.0.0"
 ---
 
 ## Overview

--- a/content/docs/connectors/authproxy.md
+++ b/content/docs/connectors/authproxy.md
@@ -6,6 +6,7 @@ date: 2020-09-30
 draft: false
 toc: true
 weight: 2090
+versionintroduced: "v0.0.0"
 ---
 
 NOTE: This connector is experimental and may change in the future.

--- a/content/docs/connectors/bitbucketcloud.md
+++ b/content/docs/connectors/bitbucketcloud.md
@@ -6,6 +6,7 @@ date: 2020-09-30
 draft: false
 toc: true
 weight: 2100
+versionintroduced: "v0.0.0"
 ---
 
 ## Overview

--- a/content/docs/connectors/gitea.md
+++ b/content/docs/connectors/gitea.md
@@ -6,6 +6,7 @@ date: 2020-09-30
 draft: false
 toc: true
 weight: 2130
+versionintroduced: "v0.0.0"
 ---
 
 ## Overview

--- a/content/docs/connectors/github.md
+++ b/content/docs/connectors/github.md
@@ -6,6 +6,7 @@ date: 2020-09-30
 draft: false
 toc: true
 weight: 2020
+versionintroduced: "v0.0.0"
 ---
 
 ## Overview

--- a/content/docs/connectors/gitlab.md
+++ b/content/docs/connectors/gitlab.md
@@ -6,6 +6,7 @@ date: 2020-09-30
 draft: false
 toc: true
 weight: 2040
+versionintroduced: "v0.0.0"
 ---
 
 ## Overview

--- a/content/docs/connectors/google.md
+++ b/content/docs/connectors/google.md
@@ -6,6 +6,7 @@ date: 2020-09-30
 draft: false
 toc: true
 weight: 2060
+versionintroduced: "v0.0.0"
 ---
 
 ## Overview

--- a/content/docs/connectors/kubelogin-activedirectory.md
+++ b/content/docs/connectors/kubelogin-activedirectory.md
@@ -6,6 +6,7 @@ date: 2020-09-30
 draft: false
 toc: true
 weight: 2140
+versionintroduced: "v0.0.0"
 ---
 
 ## Overview

--- a/content/docs/connectors/ldap.md
+++ b/content/docs/connectors/ldap.md
@@ -6,6 +6,7 @@ date: 2020-09-30
 draft: false
 toc: true
 weight: 2010
+versionintroduced: "v0.0.0"
 ---
 
 ## Overview

--- a/content/docs/connectors/linkedin.md
+++ b/content/docs/connectors/linkedin.md
@@ -6,6 +6,7 @@ date: 2020-09-30
 draft: false
 toc: true
 weight: 2070
+versionintroduced: "v0.0.0"
 ---
 
 ## Overview

--- a/content/docs/connectors/microsoft.md
+++ b/content/docs/connectors/microsoft.md
@@ -6,6 +6,7 @@ date: 2020-09-30
 draft: false
 toc: true
 weight: 2080
+versionintroduced: "v0.0.0"
 ---
 
 ## Overview

--- a/content/docs/connectors/oidc.md
+++ b/content/docs/connectors/oidc.md
@@ -6,6 +6,7 @@ date: 2020-09-30
 draft: false
 toc: true
 weight: 2050
+versionintroduced: "v0.0.0"
 ---
 
 ## Overview

--- a/content/docs/connectors/openshift.md
+++ b/content/docs/connectors/openshift.md
@@ -6,6 +6,7 @@ date: 2020-09-30
 draft: false
 toc: true
 weight: 2110
+versionintroduced: "v0.0.0"
 ---
 
 ## Overview

--- a/content/docs/connectors/saml.md
+++ b/content/docs/connectors/saml.md
@@ -6,6 +6,7 @@ date: 2020-09-30
 draft: false
 toc: true
 weight: 2030
+versionintroduced: "v0.0.0"
 ---
 
 ## WARNING

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -14,6 +14,11 @@
         <section class="col col-8">
           <h1 class="title">{{ .Page.Title | markdownify }}</h1>
           <p class="subtitle">{{ .Page.Description | markdownify }}</p>
+          {{ if ((isset .Params "versionintroduced") | and (ne .Params.versionintroduced "")) }}
+          <div class="is-size-7">
+          Since: {{ .Params.versionintroduced }}
+          </div>
+          {{ end }}
           {{ partial "docs/content.html" . }}
         </section>
       </section>


### PR DESCRIPTION
Adding `versionintroduced` variable to frontmatter of connector pages, and updating the `single.html` file to display a "Since v0.0.0" message if it is set.

I don't know when each connector was introduced, so @sagikazarmark, @nabokihms please suggest one using the ` ```suggest` notation for each of the files updated.

closes: https://github.com/dexidp/website/issues/92