### PR TITLE
docs: Add acr_values field description into the docs

### DIFF
--- a/content/docs/connectors/oidc.md
+++ b/content/docs/connectors/oidc.md
@@ -89,6 +89,13 @@ connectors:
     # Default: name
     # userNameKey: nickname
 
+    # The acr_values variable specifies the Authentication Context Class Values within
+    # the Authentication Request that the Authorization Server is being requested to process
+    # from this Client.
+    # acrValues: 
+    #  - <value>
+    #  - <value>
+
     # For offline_access, the prompt parameter is set by default to "prompt=consent". 
     # However this is not supported by all OIDC providers, some of them support different
     # value for prompt, like "prompt=login" or "prompt=none"


### PR DESCRIPTION
Hi,

This PR adds the description for the new config field `acrValues`

the original issue is here -> https://github.com/dexidp/dex/issues/2417


Signed-off-by: Engin Diri <engin.diri@mail.schwarz>