### PR TITLE
Remove stale caveat that indicates changed upstream claims won't be sent downstream from dex

### DIFF
--- a/content/docs/connectors/oidc.md
+++ b/content/docs/connectors/oidc.md
@@ -14,10 +14,6 @@ Dex is able to use another OpenID Connect provider as an authentication source. 
 
 Prominent examples of OpenID Connect providers include Google Accounts, Salesforce, and Azure AD v2 ([not v1][azure-ad-v1]).
 
-## Caveats
-
-When using refresh tokens, changes to the upstream claims aren't propagated to the id_token returned by dex. If a user's email changes, the "email" claim returned by dex won't change unless the user logs in again. Progress for this is tracked in [issue #863][issue-863].
-
 ## Configuration
 
 ```yaml


### PR DESCRIPTION
This caveat seems to be stale. It references https://github.com/dexidp/dex/issues/863, which was closed in https://github.com/dexidp/dex/pull/1180. Looking at the PR this does seem to propagate the upstream claims downstream on refresh, and in my (albeit limited) testing changed claims do come down in the dex ID token. 

Possible I'm incorrect here, but as far as I can see this is just a doc bug and the actual functionality has been there for a while. 

Signed-off-by: Anthony Brandelli <abrandel@cisco.com>