### PR TITLE
Fix using ldapsearch deprecated -h option in ldap.md

### DIFF
--- a/content/docs/connectors/ldap.md
+++ b/content/docs/connectors/ldap.md
@@ -163,7 +163,7 @@ sudo apt-get install ldap-utils
 For smaller user directories it may be practical to dump the entire contents and search by hand.
 
 ```bash
-ldapsearch -x -h ldap.example.org -b 'dc=example,dc=org' | less
+ldapsearch -x -H ldap://ldap.example.org -b 'dc=example,dc=org' | less
 ```
 
 First, find a user entry. User entries declare users who can login to LDAP connector using username and password.


### PR DESCRIPTION
The `-h` option of ldapsearch was [deprecated](https://www.openldap.org/software/man.cgi?query=ldapsearch&apropos=0&sektion=1&manpath=OpenLDAP+2.0-Release&arch=default&format=html) in favor of `-H` since OpenLDAP 2.0 (which was [released](https://en.wikipedia.org/wiki/OpenLDAP#Release_summary) in August 2000, a long long time ago), and is [removed](https://www.openldap.org/doc/admin25/appendix-upgrading.html#Client%20utility%20changes)  since version 2.5. 

So we should use `-H` instead.