### PR TITLE
Microsoft Connector: domainHint configuration parameter

### DIFF
--- a/content/docs/connectors/microsoft.md
+++ b/content/docs/connectors/microsoft.md
@@ -88,6 +88,39 @@ connectors:
       tenant: organizations
 ```
 
+`domainHint` configuration parameter allows for a more streamlined login
+experience when the email domain is common to all users of the connector.
+By default, users with multiple Microsoft sessions will be prompted to choose
+which account they want to use for login.  When `domainHint` is configured,
+Microsoft will select the session with matching email without the interactive
+prompt.
+
+For example: user John Doe has 2 active Microsoft sessions:
+
+- John.Doe@live.com (consumer)
+- John.Doe@example.com (organization)
+
+If Example Organization configures the `domainHint` parameter with its
+organization's email suffix, John will not be prompted to select an account
+from the active sessions.  Instead, the matching organization session is
+selected automatically.
+
+```yaml
+connectors:
+  - type: microsoft
+    # Required field for connector id.
+    id: microsoft
+    # Required field for connector name.
+    name: Microsoft
+    config:
+      # Credentials can be string literals or pulled from the environment.
+      clientID: $MICROSOFT_APPLICATION_ID
+      clientSecret: $MICROSOFT_CLIENT_SECRET
+      redirectURI: http://127.0.0.1:5556/dex/callback
+      tenant: example.onmicrosoft.com
+      domainHint: example.com
+```
+
 ### Groups
 
 When the `groups` claim is present in a request to dex __and__ `tenant` is


### PR DESCRIPTION
Adds a description and example usage for using the `domainHint` configuration parameter added in PR https://github.com/dexidp/dex/pull/2586

This enhancement was added to address issue https://github.com/dexidp/dex/issues/2585