### PR TITLE
docs (storage): Add host and port fields for postgres

### DIFF
--- a/content/docs/storage.md
+++ b/content/docs/storage.md
@@ -183,6 +183,8 @@ An example config for Postgres setup using these values:
 storage:
   type: postgres
   config:
+    host: localhost
+    port: 5432
     database: dex_db
     user: dex
     password: 66964843358242dbaaa7778d8477c288


### PR DESCRIPTION
Just did a recent deployment of Dex one one of the clusters and it
took me a while to find the proper configuration. My initial
impression was that the field database should contain the host and
port information along with database name in some form of URI which
isn't correct. Having the host & port field would have saved me some
time.