### PR TITLE
custom-scopes-claims-clients.md: public client secret

### DIFF
--- a/content/docs/custom-scopes-claims-clients.md
+++ b/content/docs/custom-scopes-claims-clients.md
@@ -94,7 +94,6 @@ staticClients:
 - id: cli-app
   public: true
   name: 'CLI app'
-  secret: cli-app-secret
 ```
 
 Instead of traditional redirect URIs, public clients are limited to either redirects that begin with "http://localhost" or a special "out-of-browser" URL "urn:ietf:wg:oauth:2.0:oob". The latter triggers dex to display the OAuth2 code in the browser, prompting the end user to manually copy it to their app. It's the client's responsibility to either create a screen or a prompt to receive the code, then perform a code exchange for a token response.


### PR DESCRIPTION
Public clients should not have a secret as also discussed in https://github.com/dexidp/dex/pull/2540.