### PR TITLE
fix: set minimum go version requirement to 1.19

### DIFF
--- a/content/docs/getting-started.md
+++ b/content/docs/getting-started.md
@@ -9,7 +9,7 @@ weight: 1010
 
 ## Building the dex binary
 
-To build dex from source code, install a working Go environment with version 1.15 or greater according to the [official documentation][go-setup].
+To build dex from source code, install a working Go environment with version 1.19 or greater according to the [official documentation][go-setup].
 Then clone the repository and use `make` to compile the dex binary.
 
 ```bash


### PR DESCRIPTION
Fix https://github.com/dexidp/dex/issues/2749