### PR TITLE
public client documentation

### DIFF
--- a/content/docs/custom-scopes-claims-clients.md
+++ b/content/docs/custom-scopes-claims-clients.md
@@ -94,10 +94,12 @@ staticClients:
 - id: cli-app
   public: true
   name: 'CLI app'
-  secret: cli-app-secret
+  redirectURIs:
+  - ...
 ```
 
-Instead of traditional redirect URIs, public clients are limited to either redirects that begin with "http://localhost" or a special "out-of-browser" URL "urn:ietf:wg:oauth:2.0:oob". The latter triggers dex to display the OAuth2 code in the browser, prompting the end user to manually copy it to their app. It's the client's responsibility to either create a screen or a prompt to receive the code, then perform a code exchange for a token response.
+If no `redirectURIs` are specified, public clients only support redirects that begin with "http://localhost" or a special "out-of-browser" URL "urn:ietf:wg:oauth:2.0:oob".
+The latter triggers dex to display the OAuth2 code in the browser, prompting the end user to manually copy it to their app. It's the client's responsibility to either create a screen or a prompt to receive the code, then perform a code exchange for a token response.
 
 When using the "out-of-browser" flow, an ID Token nonce is strongly recommended.
 


### PR DESCRIPTION
The PRs https://github.com/dexidp/dex/pull/1784 and https://github.com/dexidp/dex/pull/1822 are super useful, but the documentation can be confusing.

First, it does not make sense to specify a secret in a public client because it will require you to pass the secret to the public client, which will make the secret "not secret".

Also, as of https://github.com/dexidp/dex/pull/1822, it is possible to use `redirectURIs` in a public client.

Signed-off-by: leonnicolas <60091705+leonnicolas@users.noreply.github.com>