### PR TITLE
Update Reference link to openid-connect-tokens for api-server authentication

### DIFF
--- a/content/docs/id-tokens.md
+++ b/content/docs/id-tokens.md
@@ -81,7 +81,7 @@ __NOTE__: `disableRotation` and `reuseInterval` options help effectively deal wi
 [aws-sts]: https://docs.aws.amazon.com/STS/latest/APIReference/Welcome.html
 [connectors]: connectors
 [jwt-io]: https://jwt.io/
-[kubernetes]: http://kubernetes.io/docs/admin/authentication/#openid-connect-tokens
+[kubernetes]: https://kubernetes.io/docs/reference/access-authn-authz/authentication/#openid-connect-tokens
 [rfc6819-5.2.2.3]: https://tools.ietf.org/html/rfc6819#section-5.2.2.3
 [standard-claims]: https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims
 [using-dex]: using-dex

--- a/content/docs/kubernetes.md
+++ b/content/docs/kubernetes.md
@@ -192,7 +192,7 @@ users:
 ```
 
 [k8s-authz]: http://kubernetes.io/docs/admin/authorization/
-[k8s-oidc]: http://kubernetes.io/docs/admin/authentication/#openid-connect-tokens
+[k8s-oidc]: https://kubernetes.io/docs/reference/access-authn-authz/authentication/#openid-connect-tokens
 [trusted-peers]: https://godoc.org/github.com/dexidp/dex/storage#Client
 [coreos-kubernetes]: https://github.com/coreos/coreos-kubernetes/
 [coreos-baremetal]: https://github.com/coreos/coreos-baremetal/

--- a/content/docs/using-dex.md
+++ b/content/docs/using-dex.md
@@ -189,7 +189,7 @@ func authorize(ctx context.Context, bearerToken string) (*user, error) {
 }
 ```
 
-[api-server]: https://kubernetes.io/docs/admin/authentication/#openid-connect-tokens
+[api-server]: https://kubernetes.io/docs/reference/access-authn-authz/authentication/#openid-connect-tokens
 [dex-flow]: img/dex-flow.png
 [dex-backend-flow]: img/dex-backend-flow.png
 [example-app]: https://github.com/dexidp/dex/tree/master/examples/example-app


### PR DESCRIPTION
The page has moved to the new link:
- updated all the references to new link. (since the content also have not changed , just the content was moved to different URL).