### PR TITLE
Less misleading docs wrt. tenant in Microsoft connector

### DIFF
--- a/content/docs/connectors/microsoft.md
+++ b/content/docs/connectors/microsoft.md
@@ -22,9 +22,11 @@ authenticated them through Microsoft.
 ### Caveats
 
 `groups` claim in dex is only supported when `tenant` is specified in Microsoft
-connector config. In order for dex to be able to list groups on behalf of
-logged in user, an explicit organization administrator consent is required. To
-obtain the consent do the following:
+connector config. Furthermore, `tenant` must also be configured to either 
+`<tenant uuid>` or `<tenant name>` (see [Configuration](#configuration)). In 
+order for dex to be able to list groups on behalf of logged in user, an 
+explicit organization administrator consent is required. To obtain the 
+consent do the following:
 
   - when registering dex application on https://apps.dev.microsoft.com add
     an explicit `Directory.Read.All` permission to the list of __Delegated
@@ -126,6 +128,10 @@ configured, dex will query Microsoft API to obtain a list of groups the user is
 a member of. `onlySecurityGroups` configuration option restricts the list to
 include only security groups. By default all groups (security, Office 365,
 mailing lists) are included.
+
+Please note that `tenant` must be configured to either `<tenant uuid>` or 
+`<tenant name>` for this to work. For more details on `tenant` configuration,
+see [Configuration](#configuration).
 
 By default, dex resolve groups ids to groups names, to keep groups ids, you can
 specify the configuration option `groupNameFormat: id`.


### PR DESCRIPTION
The current documentation for getting groups from Azure in the Microsoft connector makes it seem like any valid `tenant` configuration is enough to get groups from Azure. This is however not the case, as Dex specifically checks if `tenant` is not set to `common`, `consumers` or `organizations` (as seen here: https://github.com/dexidp/dex/blob/295b0acd61055b5e17a1b1c74908a0c723a62a17/connector/microsoft/microsoft.go#L132).

If a user has for example configured `groups` in their connector after reading the documentation, then they would expect to get groups out when authenticating via Dex. However if `tenant` has not been set to either `<tenant uuid>` or `<tenant name>`, then the groups lookup will not happen. And neither the docs nor the Dex containers own logs make any mention of this.

Therefore, this PR adds a couple of lines to instruct the user in what constitues a valid `tenant` configuration if a group lookup is desired.