### PR TITLE
Document the case sensitivity of the github connector.

### DIFF
--- a/content/docs/connectors/github.md
+++ b/content/docs/connectors/github.md
@@ -18,6 +18,8 @@ When a client redeems a refresh token through dex, dex will re-query GitHub to u
 
 * A user must explicitly [request][github-request-org-access] an [organization][github-orgs] give dex [resource access][github-approve-org-access]. Dex will not have the correct permissions to determine if the user is in that organization otherwise, and the user will not be able to log in. This request mechanism is a feature of the GitHub API.
 
+* The organisation and team names are **case sensitive**. Dex will not have the correct team name to determine the right roles.
+
 ## Configuration
 
 Register a new application with [GitHub][github-oauth2] ensuring the callback URL is `(dex issuer)/callback`. For example if dex is listening at the non-root path `https://auth.example.com/dex` the callback would be `https://auth.example.com/dex/callback`.


### PR DESCRIPTION
I ran into an issue where i was able to log in through the Github connector with the organisation name all in small caps but my team did not get through. After adding the right capitals in the organisation name, everything worked. The error was rather silent and I've lost some time on it :) 

A small note in the disclaimer could have saved me a few hours ;) 