### PR TITLE
Fix type of field rootCAs in connector oauth

### DIFF
--- a/content/docs/connectors/oauth.md
+++ b/content/docs/connectors/oauth.md
@@ -38,7 +38,8 @@ connectors:
 
     # Optional: The location of file containing SSL certificates to communicate
     # to Auth provider
-    # rootCAs: /etc/ssl/reddit.pem
+    # rootCAs:
+    # - /etc/ssl/reddit.pem
 
     # Optional: List of scopes to request Auth provider for access user account
     # scopes:


### PR DESCRIPTION
Fixes following error:

```
error parse config file /tmp/dex.yaml: error unmarshaling JSON: parse connector config: json: cannot unmarshal string into Go struct field Config.rootCAs of type []string
```