### PR TITLE
fix: update deprecated reference for using google SA

### DIFF
--- a/content/docs/connectors/google.md
+++ b/content/docs/connectors/google.md
@@ -50,7 +50,8 @@ connectors:
     # of a G Suite admin to impersonate:
     #
     #serviceAccountFilePath: googleAuth.json
-    #adminEmail: super-user@example.com
+    #domainToAdminEmail:
+    #  example.com: super-user@example.com
 ```
 
 ## Fetching groups from Google
@@ -65,4 +66,4 @@ To get group fetching set up:
 2. Enable the [Admin SDK](https://console.developers.google.com/apis/library/admin.googleapis.com/)
 3. Add the `serviceAccountFilePath` and `adminEmail` configuration options to your Dex config.
   - `serviceAccountFilePath` should point to the location of the service account JSON key file
-  - `adminEmail` should be the email of a Google Workspace user with a minimum of the `Groups Reader (BETA)` Role assigned. The service account you created earlier will impersonate this user when making calls to the admin API. A valid user should be able to retrieve a list of groups when [testing the API](https://developers.google.com/admin-sdk/directory/v1/reference/groups/list#try-it).
+  - `domainToAdminEmail` should be mapping between the base domain and the email of a Google Workspace user with a minimum of the `Groups Reader (BETA)` Role assigned. The service account you created earlier will impersonate this user when making calls to the admin API. A valid user should be able to retrieve a list of groups when [testing the API](https://developers.google.com/admin-sdk/directory/v1/reference/groups/list#try-it).


### PR DESCRIPTION
Removes a deprecated option for using google SA and uses the current option instead.

Resolves https://github.com/dexidp/website/issues/150