### PR TITLE
FIX: document secretEnv on oidc config to inject oidc secret env vars

### DIFF
--- a/content/docs/custom-scopes-claims-clients.md
+++ b/content/docs/custom-scopes-claims-clients.md
@@ -57,6 +57,8 @@ staticClients:
   - 'https://web-app.example.com/callback'
   name: 'Web app'
   secret: web-app-secret
+  # It is also possible to fetch the secret from an inject environment variable
+  # secretEnv: YOUR_INJECTED_SECRET
 
 - id: cli-app
   redirectURIs:

--- a/content/docs/custom-scopes-claims-clients.md
+++ b/content/docs/custom-scopes-claims-clients.md
@@ -57,7 +57,7 @@ staticClients:
   - 'https://web-app.example.com/callback'
   name: 'Web app'
   secret: web-app-secret
-  # It is also possible to fetch the secret from an inject environment variable
+  # It is also possible to fetch the secret from an injected environment variable
   # secretEnv: YOUR_INJECTED_SECRET
 
 - id: cli-app


### PR DESCRIPTION
https://github.com/dexidp/dex/blob/ed920dc27ad79c3593037ad658552e8e80bab928/cmd/dex/serve.go#L207

This functionality was never documented. Lmk if you'd like to see it somewhere else.