### PR TITLE
Update the GitHub connector docs

### DIFF
--- a/content/docs/connectors/github.md
+++ b/content/docs/connectors/github.md
@@ -37,47 +37,55 @@ connectors:
     clientSecret: $GITHUB_CLIENT_SECRET
     redirectURI: http://127.0.0.1:5556/dex/callback
 
-    # Optional organizations and teams, communicated through the "groups" scope.
-    #
-    # NOTE: This is an EXPERIMENTAL config option and will likely change.
-    #
-    # Legacy 'org' field. 'org' and 'orgs' cannot be used simultaneously. A user
-    # MUST be a member of the following org to authenticate with dex.
-    # org: my-organization
-    #
-    # Dex queries the following organizations for group information if the
-    # "groups" scope is provided. Group claims are formatted as "(org):(team)".
-    # For example if a user is part of the "engineering" team of the "coreos"
-    # org, the group claim would include "coreos:engineering".
-    #
-    # If orgs are specified in the config then user MUST be a member of at least one of the specified orgs to
-    # authenticate with dex.
-    #
-    # If neither 'org' nor 'orgs' are specified in the config and 'loadAllGroups' setting set to true then user
-    # authenticate with ALL user's GitHub groups. Typical use case for this setup:
-    # provide read-only access to everyone and give full permissions if user has 'my-organization:admins-team' group claim.  
+    # Legacy 'org' field.
+    #  - A user MUST be a member of the following org to authenticate with dex.
+    #  - Both 'org' and 'orgs' can NOT be used simultaneously.
+    #org: my-organization
+
+    # List of org and team names.
+    #  - If specified, a user MUST be a member of at least ONE of these orgs
+    #    and teams (if set) to authenticate with dex.
+    #  - Dex queries the following organizations for group information if the
+    #    "groups" scope is requested. Group claims are formatted as "(org):(team)".
+    #    For example if a user is part of the "engineering" team of the "coreos" org,
+    #    the group claim would include "coreos:engineering".
+    #  - If teams are specified, dex only returns group claims for those teams.
     orgs:
     - name: my-organization
-      # Include all teams as claims.
     - name: my-organization-with-teams
-      # A white list of teams. Only include group claims for these teams.
       teams:
       - red-team
       - blue-team
-    # Flag which indicates that all user groups and teams should be loaded.
+
+    # Flag which indicates that all the user's orgs and teams should be loaded.
+    # Only works if neither 'org' nor 'orgs' are specified in the config.
     loadAllGroups: false
 
-    # Optional choice between 'name' (default), 'slug', or 'both'.
-    #
-    # As an example, group claims for member of 'Site Reliability Engineers' in
-    # Acme organization would yield:
-    #   - ['acme:Site Reliability Engineers'] for 'name'
-    #   - ['acme:site-reliability-engineers'] for 'slug'
-    #   - ['acme:Site Reliability Engineers', 'acme:site-reliability-engineers'] for 'both'
+    # How the team names are formatted.
+    #  - Options: 'name' (default), 'slug', 'both'.
+    #  - Examples:
+    #    - 'name': 'acme:Site Reliability Engineers'
+    #    - 'slug': 'acme:site-reliability-engineers'
+    #    - 'both': 'acme:Site Reliability Engineers', 'acme:site-reliability-engineers'
     teamNameField: slug
-    # flag which will switch from using the internal GitHub id to the users handle (@mention) as the user id.
-    # It is possible for a user to change their own user name but it is very rare for them to do so
+
+    # Flag which will switch from using the internal GitHub id to the users handle (@mention) as the user id.
+    # It is possible for a user to change their own username, but it is very rare for them to do so
     useLoginAsID: false
+
+    # A preferred email domain to use when returning the user's email.
+    #  - If the user has a PUBLIC email, it is ALWAYS returned in the email claim,
+    #    so this field would have NO effect (this may change in the future).
+    #  - By default, if the user does NOT have a public email, their primary email is returned.
+    #  - When 'preferredEmailDomain' is set, the first email matching this domain is returned,
+    #    we fall back to the primary email if no match is found.
+    #  - To allow multiple subdomains, you may specify a wildcard like "*.example.com"
+    #    which will match "aaaa.example.com" and "bbbb.example.com", but NOT "example.com".
+    #  - To return the user's no-reply email, set this field to "users.noreply.github.com",
+    #    this is a mostly static email that GitHub assigns to the user. These emails
+    #    are formatted like 'ID+USERNAME@users.noreply.github.com' for newer accounts
+    #    and 'USERNAME@users.noreply.github.com' for older accounts.
+    #preferredEmailDomain: "example.com"
 ```
 
 ## GitHub Enterprise
@@ -98,33 +106,39 @@ connectors:
     clientID: $GITHUB_CLIENT_ID
     clientSecret: $GITHUB_CLIENT_SECRET
     redirectURI: http://127.0.0.1:5556/dex/callback
-    # Optional organizations and teams, communicated through the "groups" scope.
-    #
-    # NOTE: This is an EXPERIMENTAL config option and will likely change.
-    #
-    # Legacy 'org' field. 'org' and 'orgs' cannot be used simultaneously. A user
-    # MUST be a member of the following org to authenticate with dex.
-    # org: my-organization
-    #
-    # Dex queries the following organizations for group information if the
-    # "groups" scope is provided. Group claims are formatted as "(org):(team)".
-    # For example if a user is part of the "engineering" team of the "coreos"
-    # org, the group claim would include "coreos:engineering".
-    #
-    # A user MUST be a member of at least one of the following orgs to
-    # authenticate with dex.
+
+    # List of org and team names.
+    #  - If specified, a user MUST be a member of at least ONE of these orgs
+    #    and teams (if set) to authenticate with dex.
+    #  - Dex queries the following organizations for group information if the
+    #    "groups" scope is requested. Group claims are formatted as "(org):(team)".
+    #    For example if a user is part of the "engineering" team of the "coreos" org,
+    #    the group claim would include "coreos:engineering".
+    #  - If teams are specified, dex only returns group claims for those teams.
     orgs:
     - name: my-organization
-      # Include all teams as claims.
     - name: my-organization-with-teams
-      # A white list of teams. Only include group claims for these teams.
       teams:
       - red-team
       - blue-team
+
+    # Flag which indicates that all the user's orgs and teams should be loaded.
+    # Only works if neither 'org' nor 'orgs' are specified in the config.
+    loadAllGroups: false
+
+    # How the team names are formatted
+    #  - Options: 'name' (default), 'slug', 'both'.
+    #  - Examples:
+    #    - 'name': 'acme:Site Reliability Engineers'
+    #    - 'slug': 'acme:site-reliability-engineers'
+    #    - 'both': 'acme:Site Reliability Engineers', 'acme:site-reliability-engineers'
+    teamNameField: slug
+
     # Required ONLY for GitHub Enterprise.
     # This is the Hostname of the GitHub Enterprise account listed on the
     # management console. Ensure this domain is routable on your network.
     hostName: git.example.com
+
     # ONLY for GitHub Enterprise. Optional field.
     # Used to support self-signed or untrusted CA root certificates.
     rootCA: /etc/dex/ca.crt
@@ -137,7 +151,7 @@ Running Dex with HTTPS enabled requires a valid SSL certificate, and the API ser
 For our example use case, the TLS assets can be created using the following command:
 
 ```bash
-$ ./examples/k8s/gencert.sh 
+$ ./examples/k8s/gencert.sh
 ```
 
 This will generate several files under the `ssl` directory, the important ones being `cert.pem` ,`key.pem` and `ca.pem`. The generated SSL certificate is for 'dex.example.com', although you could change this by editing `gencert.sh` if required.


### PR DESCRIPTION
The GitHub connector docs were very hard to read before, and did not include any reference to the very important `preferredEmailDomain` feature added by https://github.com/dexidp/dex/pull/2740