### PR TITLE
Document usage of 'issuerAlias' config in OIDC connector

### DIFF
--- a/content/docs/connectors/oidc.md
+++ b/content/docs/connectors/oidc.md
@@ -28,6 +28,12 @@ connectors:
     # See: https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig
     issuer: https://accounts.google.com
 
+    # Some offspec providers like Azure, Oracle IDCS have oidc discovery url
+    # different from issuer url which causes issuerValidation to fail
+    # issuerAlias provides a way to override the Issuer url
+    # from the .well-known/openid-configuration issuer
+    # issuerAlias: https://accounts.google.com
+
     # Connector config values starting with a "$" will read from the environment.
     clientID: $GOOGLE_CLIENT_ID
     clientSecret: $GOOGLE_CLIENT_SECRET


### PR DESCRIPTION
Some Identity Providers like IDCS and Azure have different issuer urls in the OIDC discovery endpoint. This leads to the issuer url check failing. 
https://github.com/dexidp/dex/pull/3676 introduces a mechanism to fix this using a new configuration attribute `issuerAlias`.

This PR documents the usage of this new configuration `issuerAlias` in the OIDC Connector