### PR TITLE
refactor: change value redirectURI from `http://127.0.0.1:5556/callback` to `http://127.0.0.1:5556/dex/callback`

### DIFF
--- a/content/docs/connectors/google.md
+++ b/content/docs/connectors/google.md
@@ -28,7 +28,7 @@ connectors:
     clientSecret: $GOOGLE_CLIENT_SECRET
 
     # Dex's issuer URL + "/callback"
-    redirectURI: http://127.0.0.1:5556/callback
+    redirectURI: http://127.0.0.1:5556/dex/callback
 
     # Set the value of `prompt` query parameter in the authorization request
     # The default value is "consent" when not set.

--- a/content/docs/connectors/oauth.md
+++ b/content/docs/connectors/oauth.md
@@ -26,7 +26,7 @@ connectors:
     # Connector config values starting with a "$" will read from the environment.
     clientID: $REDDIT_CLIENT_ID
     clientSecret: $REDDIT_CLIENT_SECRET
-    redirectURI: http://127.0.0.1:5556/callback
+    redirectURI: http://127.0.0.1:5556/dex/callback
 
     tokenURL: https://www.reddit.com/api/v1/access_token
     authorizationURL: https://www.reddit.com/api/v1/authorize

--- a/content/docs/connectors/oidc.md
+++ b/content/docs/connectors/oidc.md
@@ -33,7 +33,7 @@ connectors:
     clientSecret: $GOOGLE_CLIENT_SECRET
 
     # Dex's issuer URL + "/callback"
-    redirectURI: http://127.0.0.1:5556/callback
+    redirectURI: http://127.0.0.1:5556/dex/callback
 
 
     # Some providers require passing client_secret via POST parameters instead


### PR DESCRIPTION
Some files are still using an outdated `redirectURI` callback: `http://127.0.0.1:5556/callback`. It should be updated to `http://127.0.0.1:5556/dex/callback`.
