### PR TITLE
Update Google docs about refresh tokens support

### DIFF
--- a/content/docs/connectors/google.md
+++ b/content/docs/connectors/google.md
@@ -83,4 +83,5 @@ time they log in.
 To change this behavior, you can set the `promptType` field in config file to
 any OIDC-supported value. To skip the consent screen for every authorization
 request, set `promptType` to `""` (empty string) to fall back to Google's
-default behavior.
+default behavior. Google does not support refreshing tokens when `promptType`
+is set to `""`.


### PR DESCRIPTION
Hi! Thanks very much for Dex!

Refresh tokens were working great until I set `promptType` to `""`. I see these logs on Dex when trying to use a refresh token with this setting:

```
time=2025-12-23T11:27:45.787Z level=ERROR msg="failed to refresh identity" err="google: failed to get token: oauth2: token expired and refresh token is not set" request_id=dcb2ecf2-720f-42a1-ae54-4feb7e1fd868
time=2025-12-23T11:27:45.797Z level=ERROR msg="failed to update refresh token" err="refresh token error: status 500, \"invalid_request\" " request_id=dcb2ecf2-720f-42a1-ae54-4feb7e1fd868
```