### PR TITLE
Change SAML 2.0 status to deprecated

### DIFF
--- a/content/docs/connectors/_index.md
+++ b/content/docs/connectors/_index.md
@@ -21,7 +21,7 @@ Dex implements the following connectors:
 | ---- | ----------------------- | --------------------- | --------------------------------- | ------ | ----- |
 | [LDAP](/docs/connectors/ldap/) | yes | yes | yes | stable | |
 | [GitHub](/docs/connectors/github/) | yes | yes | yes | stable | |
-| [SAML 2.0](/docs/connectors/saml/) | no | yes | no | stable |
+| [SAML 2.0](/docs/connectors/saml/) | no | yes | no | deprecated |
 | [GitLab](/docs/connectors/gitlab/) | yes | yes | yes | beta | |
 | [OpenID Connect](/docs/connectors/oidc/) | yes | yes | yes | beta | Includes Salesforce, Azure, etc. |
 | [OAuth 2.0](/docs/connectors/oauth/) | no | yes | yes | alpha |
@@ -36,9 +36,10 @@ Dex implements the following connectors:
 | [OpenStack Keystone](/docs/connectors/keystone/) | yes | yes | no | alpha |  |
 
 
-Stable, beta, and alpha are defined as:
+Stable, deprecated, beta, and alpha are defined as:
 
 * Stable: well tested, in active use, and will not change in backward incompatible ways.
+* Deprecated: no longer actively maintained
 * Beta: tested and unlikely to change in backward incompatible ways.
 * Alpha: may be untested by core maintainers and is subject to change in backward incompatible ways.
 


### PR DESCRIPTION
Updated the status of the SAML 2.0 connector to 'deprecated' and modified the definition section to include 'deprecated'.

See the warning header at the top of SAML:

> The SAML connector is unmaintained, likely vulnerable to authentication bypass vulnerabilities, and is under consideration for deprecation (see [#1884](https://github.com/dexidp/dex/discussions/1884)). Please consider switching to OpenID Connect, OAuth2, or LDAP for identity providers that support these protocols. If you have domain expertise in SAML/XMLDSig and would like to volunteer to maintain the connector please comment on the discussion.

It is therefore not reasonable to describe SAML support as 'stable'.   

Describing SAML support as `stable` is not an accurate description of its present state, nor is it in-line with general industry acceptance of what the word 'stable' means.  'obsolete' is likely a fairer term, but I was being generous with 'deprecated'. 😉 

(ping https://github.com/dexidp/dex/discussions/1884)