### PR TITLE
docs(microsoft): document batchGroupLookups option

### DIFF
--- a/content/docs/connectors/microsoft.md
+++ b/content/docs/connectors/microsoft.md
@@ -209,3 +209,36 @@ connectors:
       # lowercase if config is TRUE
       emailToLowercase: true
 ```
+
+By default, dex resolves group ids to group names with a single request to
+the Microsoft Graph API. Microsoft Graph's
+[`directoryObjects/getByIds`](https://learn.microsoft.com/en-us/graph/api/directoryobject-getbyids)
+endpoint caps that request at 1000 ids, so a user who is a member of more
+than 1000 groups will fail to log in.
+
+Setting the `batchGroupLookups` (boolean) configuration option splits the
+lookup into batches of 1000 group ids, supporting users with larger group
+memberships. This is opt-in because it trades that login failure for
+additional requests to the Microsoft Graph API — one extra request per 1000
+groups a user belongs to — which may not be desirable for every deployment.
+
+```yaml
+connectors:
+  - type: microsoft
+    # Required field for connector id.
+    id: microsoft
+    # Required field for connector name.
+    name: Microsoft
+    config:
+      # Credentials can be string literals or pulled from the environment.
+      clientID: $MICROSOFT_APPLICATION_ID
+      clientSecret: $MICROSOFT_CLIENT_SECRET
+      redirectURI: http://127.0.0.1:5556/dex/callback
+      tenant: myorg.onmicrosoft.com
+      groups:
+        - developers
+        - devops
+      # Split group name lookups into batches of 1000 ids, supporting users
+      # in more than 1000 groups.
+      batchGroupLookups: true
+```

--- a/content/docs/connectors/microsoft.md
+++ b/content/docs/connectors/microsoft.md
@@ -152,8 +152,17 @@ Please note that `tenant` must be configured to either `<tenant uuid>` or
 `<tenant name>` for this to work. For more details on `tenant` configuration,
 see [Configuration](#configuration).
 
-By default, dex resolve groups ids to groups names, to keep groups ids, you can
-specify the configuration option `groupNameFormat: id`.
+By default (`groupNameFormat: name`), dex resolves group ids to group names.
+To keep group ids instead, set `groupNameFormat: id`. Name resolution uses a
+single Microsoft Graph request, which fails for users in more than 1000
+groups; set `batchGroupLookups: true` (boolean) to split the lookup into
+batches of 1000 ids instead.
+
+{{% alert title="Note" color="primary" %}}
+Resolving names for large group counts can produce a large JWT. If an
+ingress or gateway sits in front of dex, its default header buffer size may
+be too small to accept the result and may need tuning.
+{{% /alert %}}
 
 It is possible to require a user to be a member of a particular group in order
 to be successfully authenticated in dex. For example, with the following
@@ -181,7 +190,7 @@ connectors:
 Also, `useGroupsAsWhitelist` configuration option, can restrict the groups
 claims to include only the user's groups that are in the configured `groups`.
 
-You can use the emailToLowercase (boolean) configuration option to streamline 
+You can use the `emailToLowercase` (boolean) configuration option to streamline 
 UPNs (user email) from Active Directory before putting them into an id token.
 Without this option, it can be tough to match the email claim because a client 
 application doesn't know whether an email address has been added with 
@@ -208,37 +217,4 @@ connectors:
       # All relevant E-Mail Addresses delivered by AD will transformed to
       # lowercase if config is TRUE
       emailToLowercase: true
-```
-
-By default, dex resolves group ids to group names with a single request to
-the Microsoft Graph API. Microsoft Graph's
-[`directoryObjects/getByIds`](https://learn.microsoft.com/en-us/graph/api/directoryobject-getbyids)
-endpoint caps that request at 1000 ids, so a user who is a member of more
-than 1000 groups will fail to log in.
-
-Setting the `batchGroupLookups` (boolean) configuration option splits the
-lookup into batches of 1000 group ids, supporting users with larger group
-memberships. This is opt-in because it trades that login failure for
-additional requests to the Microsoft Graph API — one extra request per 1000
-groups a user belongs to — which may not be desirable for every deployment.
-
-```yaml
-connectors:
-  - type: microsoft
-    # Required field for connector id.
-    id: microsoft
-    # Required field for connector name.
-    name: Microsoft
-    config:
-      # Credentials can be string literals or pulled from the environment.
-      clientID: $MICROSOFT_APPLICATION_ID
-      clientSecret: $MICROSOFT_CLIENT_SECRET
-      redirectURI: http://127.0.0.1:5556/dex/callback
-      tenant: myorg.onmicrosoft.com
-      groups:
-        - developers
-        - devops
-      # Split group name lookups into batches of 1000 ids, supporting users
-      # in more than 1000 groups.
-      batchGroupLookups: true
 ```

--- a/content/docs/connectors/microsoft.md
+++ b/content/docs/connectors/microsoft.md
@@ -156,7 +156,25 @@ By default (`groupNameFormat: name`), dex resolves group ids to group names.
 To keep group ids instead, set `groupNameFormat: id`. Name resolution uses a
 single Microsoft Graph request, which fails for users in more than 1000
 groups; set `batchGroupLookups: true` (boolean) to split the lookup into
-batches of 1000 ids instead.
+batches of 1000 ids instead:
+
+```yaml
+connectors:
+  - type: microsoft
+    # Required field for connector id.
+    id: microsoft
+    # Required field for connector name.
+    name: Microsoft
+    config:
+      # Credentials can be string literals or pulled from the environment.
+      clientID: $MICROSOFT_APPLICATION_ID
+      clientSecret: $MICROSOFT_CLIENT_SECRET
+      redirectURI: http://127.0.0.1:5556/dex/callback
+      tenant: myorg.onmicrosoft.com
+      # Split group name lookups into batches of 1000 ids, supporting users
+      # in more than 1000 groups.
+      batchGroupLookups: true
+```
 
 {{% alert title="Note" color="primary" %}}
 Resolving names for large group counts can produce a large JWT. If an


### PR DESCRIPTION
The Microsoft connector's group-name resolution sends every group ID a user
belongs to in a single request to Microsoft Graph's
directoryObjects/getByIds endpoint. That endpoint caps requests at 1000 IDs,
so users in more than 1000 groups fail to log in.

dexidp/dex#4833 fixes this by adding a batchGroupLookups config option that
splits the lookup into batches of 1000 IDs. It's opt-in (default off) rather
than always-on.